### PR TITLE
feat: add simple keycloak jwt frontend

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Keycloak JWT Fetcher</title>
+  <style>
+    body { font-family: sans-serif; margin: 2rem; }
+    label { display: block; margin-top: 1rem; }
+    textarea { width: 100%; height: 6rem; }
+    input[type="text"], input[type="password"], input[type="url"] { width: 100%; }
+    .token-display { word-wrap: break-word; background: #f0f0f0; padding: 0.5rem; }
+  </style>
+</head>
+<body>
+  <h1>Keycloak Client Credentials Flow</h1>
+  <div id="auth-section">
+    <label>Client ID
+      <input type="text" id="clientId" />
+    </label>
+    <label>Client Secret
+      <input type="password" id="clientSecret" />
+    </label>
+    <label>Token Endpoint
+      <input type="url" id="tokenUrl" placeholder="https://host/realms/realm/protocol/openid-connect/token" />
+    </label>
+    <button id="fetchToken">Send</button>
+  </div>
+
+  <h2>Access Token</h2>
+  <div id="token" class="token-display"></div>
+
+  <div id="request-section" style="display:none;">
+    <label>Request URL
+      <input type="url" id="requestUrl" />
+    </label>
+    <button id="sendRequest">Send</button>
+    <h3>Response</h3>
+    <pre id="response"></pre>
+  </div>
+
+  <script>
+    let currentToken = '';
+
+    async function fetchToken() {
+      const clientId = document.getElementById('clientId').value;
+      const clientSecret = document.getElementById('clientSecret').value;
+      const tokenUrl = document.getElementById('tokenUrl').value;
+
+      const params = new URLSearchParams();
+      params.append('grant_type', 'client_credentials');
+      params.append('client_id', clientId);
+      params.append('client_secret', clientSecret);
+
+      try {
+        const res = await fetch(tokenUrl, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded'
+          },
+          body: params.toString()
+        });
+
+        const data = await res.json();
+        if (data.access_token) {
+          currentToken = data.access_token;
+          document.getElementById('token').textContent = currentToken;
+          document.getElementById('request-section').style.display = 'block';
+        } else {
+          document.getElementById('token').textContent = 'Failed to retrieve token';
+        }
+      } catch (err) {
+        document.getElementById('token').textContent = 'Error: ' + err;
+      }
+    }
+
+    async function sendRequest() {
+      const url = document.getElementById('requestUrl').value;
+      try {
+        const res = await fetch(url, {
+          headers: {
+            'Authorization': 'Bearer ' + currentToken
+          }
+        });
+
+        const text = await res.text();
+        document.getElementById('response').textContent = text;
+      } catch (err) {
+        document.getElementById('response').textContent = 'Request error: ' + err;
+      }
+    }
+
+    document.getElementById('fetchToken').addEventListener('click', fetchToken);
+    document.getElementById('sendRequest').addEventListener('click', sendRequest);
+  </script>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- create simple UI to retrieve Keycloak access token using client credentials
- allow sending token in Authorization header to arbitrary URL

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e4b0fa07883228b0c90dda25e9c9e